### PR TITLE
Bugfix/warc 1082 hgms iridium stations troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # USGS Iridium Short Burst Data (SBD) Decoder Library
 
-## 1.2.1 - 03/26/2019
+## 1.2.1 - 03/27/2019
  * Remove premature byte check for pseudobinary b format in SbdParser
+ * Update PseudobinaryBPayloadDecoder to use a queue, be able to decode even if all expected types aren't present, and to be sensitive to "NaN" values
 
 ## 1.2.0 - 03/25/2019
  * Add support for decoding Sutron Standard CSV messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # USGS Iridium Short Burst Data (SBD) Decoder Library
 
+## 1.2.1 - 03/26/2019
+ * 
+
 ## 1.2.0 - 03/25/2019
  * Add support for decoding Sutron Standard CSV messages
  * Update to Spring Boot 2.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # USGS Iridium Short Burst Data (SBD) Decoder Library
 
 ## 1.2.1 - 03/26/2019
- * 
+ * Remove premature byte check for pseudobinary b format in SbdParser
 
 ## 1.2.0 - 03/25/2019
  * Add support for decoding Sutron Standard CSV messages

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "warc-iridium-sbd-decoder",
     "organization": "U.S. Geological Survey",
     "description": "USGS Iridium Short Burst Data (SBD) Decoder Library",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "status": "Beta",
 
     "permissions": {
@@ -43,7 +43,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2019-03-21"
+      "metadataLastUpdated": "2019-03-26"
     }
   }
 ]

--- a/gov.usgs.warc.iridium.sbd.decoder/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.decoder/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.usgs.warc</groupId>
 	<artifactId>iridium.sbd.decoder</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<name>USGS Iridium Short Burst Data (SBD) Decoder Library</name>
 	<packaging>jar</packaging>
 

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoder.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoder.java
@@ -1,10 +1,9 @@
 package gov.usgs.warc.iridium.sbd.decoder.parser;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkElementIndex;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Queues;
 import gov.usgs.warc.iridium.sbd.decoder.parser.elements.Payload;
 import gov.usgs.warc.iridium.sbd.decoder.parser.elements.PayloadType;
 import gov.usgs.warc.iridium.sbd.decoder.sixbitbinary.Decode;
@@ -13,7 +12,12 @@ import gov.usgs.warc.iridium.sbd.domain.SbdDecodeOrder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Decoder for {@link PayloadType#PSEUDOBINARY_B_DATA_FORMAT}
@@ -24,6 +28,13 @@ import java.util.SortedSet;
  */
 public class PseudobinaryBPayloadDecoder implements PayloadDecoder
 {
+
+	/**
+	 * @author mckelvym
+	 * @since Mar 26, 2019
+	 */
+	private static final Logger log = LoggerFactory
+			.getLogger(PseudobinaryBPayloadDecoder.class);
 
 	/**
 	 * @author mckelvym
@@ -46,13 +57,16 @@ public class PseudobinaryBPayloadDecoder implements PayloadDecoder
 				.getPayloadType() == PayloadType.PSEUDOBINARY_B_DATA_FORMAT,
 				"Invalid payload type for this decoder.");
 
-		final List<Byte> payloadBytes = Lists.newArrayList();
-		for (final byte b : p_Payload.getPayload())
-		{
-			payloadBytes.add(b);
-		}
+		final byte[] payload = p_Payload.getPayload();
+		log.info(String.format("Payload:\n%s", new String(payload)));
+
+		final Queue<Byte> payloadQueue = Queues
+				.newArrayBlockingQueue(payload.length);
+		IntStream.range(0, payload.length)
+				.forEach(i -> payloadQueue.offer(payload[i]));
 
 		final Map<SbdDataType, Double> dataMap = Maps.newLinkedHashMap();
+
 		/**
 		 * Build the map of data type and its corresponding value decoded from
 		 * the payload bytes.
@@ -61,18 +75,38 @@ public class PseudobinaryBPayloadDecoder implements PayloadDecoder
 		{
 			final SbdDataType datatype = order.getDatatype();
 			final int byteLength = datatype.getBytes();
-			final int startIndex = (int) order.getByteOffset();
 
-			checkElementIndex(startIndex, payloadBytes.size(), String.format(
-					"The payload (%s; size: %s) does not have enough bytes to decode '%s' starting at byte %s.",
-					Arrays.toString(payloadBytes.toArray()),
-					payloadBytes.size(), datatype, startIndex));
+			if (payloadQueue.size() >= byteLength)
+			{
+				final List<Byte> decodeList = IntStream.range(0, byteLength)
+						.mapToObj(i -> payloadQueue.poll())
+						.collect(Collectors.toList());
+				float value = Float.NaN;
+				try
+				{
+					value = Decode.valueAtIndex(decodeList, 0,
+							decodeList.size(), 1);
+				}
+				catch (final IllegalArgumentException e)
+				{
+					log.warn(String.format(
+							"Unable to decode '%s' (%s): %s%nUsing NaN instead.",
+							datatype, Arrays.toString(decodeList.toArray()),
+							e.getMessage()));
+				}
+				final double transformedVal = Float.isNaN(value) ? Float.NaN
+						: datatype.transformValue(value);
 
-			final float value = Decode.valueAtIndex(payloadBytes, startIndex,
-					byteLength, 1);
-			final double transformedVal = datatype.transformValue(value);
-
-			dataMap.put(datatype, transformedVal);
+				log.info(String.format("Decoded '%s': %s -> %s", datatype,
+						value, transformedVal));
+				dataMap.put(datatype, transformedVal);
+			}
+			else
+			{
+				log.warn(String.format(
+						"The remaining payload (size: %s) does not have enough bytes to decode '%s': need %s byte(s).",
+						payloadQueue.size(), datatype, byteLength));
+			}
 		}
 		return dataMap;
 	}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
@@ -18,7 +18,6 @@ import gov.usgs.warc.iridium.sbd.domain.SbdDataType;
 import gov.usgs.warc.iridium.sbd.domain.SbdDecodeOrder;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -294,12 +293,6 @@ public class SbdParser
 				 * Skip the first 4 bytes of the payload.
 				 */
 				payloadArray = arrayCopyFn.apply(4);
-				for (final Byte b : payloadArray)
-				{
-					checkArgument(b >= 63,
-							"Minimum byte value for payload type %s must be 63. Payload is: %s",
-							payloadType, Arrays.toString(array));
-				}
 				break;
 			case 'C':
 				payloadType = PayloadType.PSEUDOBINARY_C_DATA_FORMAT;

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/ParsingTestsHelper.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/ParsingTestsHelper.java
@@ -309,52 +309,6 @@ public class ParsingTestsHelper
 	}
 
 	/**
-	 * @return list of List of Byte to use for testing
-	 * @author mckelvym
-	 * @since Mar 30, 2018
-	 */
-	public static List<List<Byte>> getTestingDataBadPayload()
-	{
-		final List<List<Byte>> inputByteLists = Lists.newArrayList();
-		/**
-		 * java.lang.NumberFormatException: For input string:
-		 * "-10001-10001-10001"
-		 */
-		inputByteLists.add(ParsingTestsHelper.toByteList(1, 0, 61, 1, 0, 28,
-				-101, 26, 31, 27, 51, 48, 48, 50, 51, 52, 48, 49, 48, 49, 50,
-				53, 55, 52, 48, 0, -100, 64, 0, 0, 90, -69, 75, -24, 3, 0, 11,
-				1, 29, -52, 16, 90, 29, 33, 0, 0, 0, 3, 2, 0, 13, 50, 66, 50,
-				65, 64, 66, 117, 47, 47, 47, 64, 64, 104));
-		inputByteLists.add(ParsingTestsHelper.toByteList(1, 0, 77, 1, 0, 28,
-				-99, -89, -41, 76, 51, 48, 48, 50, 51, 52, 48, 49, 48, 49, 50,
-				52, 55, 52, 48, 0, -19, -39, 0, 0, 90, -63, 90, -89, 3, 0, 11,
-				1, 29, -71, 46, 90, 19, 103, 0, 0, 0, 3, 2, 0, 29, 48, 66, 49,
-				66, 47, 47, 47, 47, 47, 47, 64, 64, 70, 64, 65, 109, 47, 47, 47,
-				47, 47, 47, 66, 94, 119, 64, 65, 80, 77));
-		return inputByteLists;
-	}
-
-	/**
-	 * @return list of List of Byte to use for testing
-	 * @author mckelvym
-	 * @since Apr 2, 2018
-	 */
-	public static List<List<Byte>> getTestingDataShortPayload()
-	{
-		final List<List<Byte>> inputByteLists = Lists.newArrayList();
-		/**
-		 * java.lang.IndexOutOfBoundsException: Invalid start index. (x) must be
-		 * less than size (y)
-		 */
-		inputByteLists.add(toByteList(1, 0, 61, 1, 0, 28, -101, 24, -84, -16,
-				51, 48, 48, 50, 51, 52, 48, 49, 48, 49, 50, 53, 55, 52, 48, 0,
-				-100, 63, 0, 0, 90, -69, 72, -50, 3, 0, 11, 1, 29, -45, 102, 90,
-				29, 33, 0, 0, 0, 4, 2, 0, 13, 50, 66, 50, 67, 64, 66, 116, 64,
-				66, 118));
-		return inputByteLists;
-	}
-
-	/**
 	 * Taken from
 	 * https://stackoverflow.com/questions/140131/convert-a-string-representation-of-a-hex-dump-to-a-byte-array-using-java
 	 *

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/directip/SbdProcessorTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/directip/SbdProcessorTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -249,25 +248,4 @@ public class SbdProcessorTest
 			}
 		}
 	}
-
-	/**
-	 * Test method for
-	 * {@link gov.usgs.warc.iridium.sbd.decoder.directip.SbdProcessorImpl#process(byte[], java.util.function.Consumer)}.
-	 */
-	@Test
-	public void testProcessBadOrShortPayload()
-	{
-		final List<List<Byte>> testingData = Lists.newArrayList();
-		testingData.addAll(ParsingTestsHelper.getTestingDataBadPayload());
-		testingData.addAll(ParsingTestsHelper.getTestingDataShortPayload());
-
-		for (final List<Byte> bytes : testingData)
-		{
-			final AtomicReference<Throwable> t = new AtomicReference<>();
-			assertThat(m_Testable.process(Bytes.toArray(bytes), t::set))
-					.isEqualTo(Optional.empty());
-			assertThat(t.get()).isNotNull();
-		}
-	}
-
 }

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
@@ -1,5 +1,14 @@
 package gov.usgs.warc.iridium.sbd.decoder.parser;
 
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.BATTERY_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.FLOOD_STAGE_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.HUMIDITY_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.PRECIPITATION_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.PRESSURE_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.PROTECTED_STAGE_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.TEMPERATURE_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.WIND_DIRECTION_DATATYPE;
+import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.WIND_SPEED_DATATYPE;
 import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.getDecodeOrderSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,7 +21,6 @@ import gov.usgs.warc.iridium.sbd.decoder.parser.elements.Payload;
 import gov.usgs.warc.iridium.sbd.decoder.parser.elements.PayloadType;
 import gov.usgs.warc.iridium.sbd.domain.SbdDataType;
 import gov.usgs.warc.iridium.sbd.domain.SbdDecodeOrder;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedSet;
@@ -95,15 +103,15 @@ public class PseudobinaryBPayloadDecoderTest
 				m_DataTypes, m_DecoderOrder);
 
 		final Map<SbdDataType, Double> expectedValues = Maps.newHashMap();
-		expectedValues.put(ParsingTestsHelper.BATTERY_DATATYPE, 13.876);
-		expectedValues.put(ParsingTestsHelper.FLOOD_STAGE_DATATYPE, -0.44);
-		expectedValues.put(ParsingTestsHelper.HUMIDITY_DATATYPE, 0.);
-		expectedValues.put(ParsingTestsHelper.PRECIPITATION_DATATYPE, 0.28);
-		expectedValues.put(ParsingTestsHelper.PRESSURE_DATATYPE, 1027.7);
-		expectedValues.put(ParsingTestsHelper.PROTECTED_STAGE_DATATYPE, -0.36);
-		expectedValues.put(ParsingTestsHelper.TEMPERATURE_DATATYPE, 39.38);
-		expectedValues.put(ParsingTestsHelper.WIND_DIRECTION_DATATYPE, 0.);
-		expectedValues.put(ParsingTestsHelper.WIND_SPEED_DATATYPE, 6.6);
+		expectedValues.put(BATTERY_DATATYPE, 13.876);
+		expectedValues.put(FLOOD_STAGE_DATATYPE, -0.44);
+		expectedValues.put(HUMIDITY_DATATYPE, 0.);
+		expectedValues.put(PRECIPITATION_DATATYPE, 0.28);
+		expectedValues.put(PRESSURE_DATATYPE, 1027.7);
+		expectedValues.put(PROTECTED_STAGE_DATATYPE, -0.36);
+		expectedValues.put(TEMPERATURE_DATATYPE, 39.38);
+		expectedValues.put(WIND_DIRECTION_DATATYPE, 0.);
+		expectedValues.put(WIND_SPEED_DATATYPE, 6.6);
 
 		for (final Entry<SbdDataType, Double> entry : expectedValues.entrySet())
 		{
@@ -112,23 +120,6 @@ public class PseudobinaryBPayloadDecoderTest
 
 			assertThat(dataMap.get(dataType)).isEqualTo(expected);
 		}
-	}
-
-	/**
-	 * Test method for
-	 * {@link gov.usgs.warc.iridium.sbd.decoder.parser.PseudobinaryBPayloadDecoder#decode(Payload, SortedSet, SortedSet)}.
-	 */
-	@Test
-	public void testDecodeBadPayload()
-	{
-		assertThatThrownBy(() -> m_Testable.decode(
-				Payload.builder(m_Payload.getPayloadType())
-						.id(m_Payload.getId())
-						.payload(Arrays.copyOf(m_Payload.getPayload(),
-								m_Payload.getPayload().length - 1))
-						.build(),
-				m_DataTypes, m_DecoderOrder))
-						.isInstanceOf(IndexOutOfBoundsException.class);
 	}
 
 	/**
@@ -145,6 +136,40 @@ public class PseudobinaryBPayloadDecoderTest
 								.payload(m_Payload.getPayload()).build(),
 						m_DataTypes, m_DecoderOrder))
 								.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	/**
+	 * Test method for
+	 * {@link gov.usgs.warc.iridium.sbd.decoder.parser.PseudobinaryBPayloadDecoder#decode(Payload, SortedSet, SortedSet)}.
+	 */
+	@Test
+	public void testDecodeShortPayload()
+	{
+		final Payload payload = Payload
+				.builder(PayloadType.PSEUDOBINARY_B_DATA_FORMAT).id((byte) 0x02)
+				.payload("?xd?zG@IC///J".getBytes()).build();
+		final Map<SbdDataType, Double> dataMap = m_Testable.decode(payload,
+				m_DataTypes, m_DecoderOrder);
+
+		final Map<SbdDataType, Double> expectedValues = Maps.newHashMap();
+		expectedValues.put(BATTERY_DATATYPE, 12.94);
+		expectedValues.put(FLOOD_STAGE_DATATYPE,
+				FLOOD_STAGE_DATATYPE.transformValue(-476));
+		expectedValues.put(PROTECTED_STAGE_DATATYPE,
+				PROTECTED_STAGE_DATATYPE.transformValue(-377));
+		expectedValues.put(WIND_SPEED_DATATYPE,
+				WIND_SPEED_DATATYPE.transformValue(579));
+		expectedValues.put(WIND_DIRECTION_DATATYPE,
+				WIND_DIRECTION_DATATYPE.transformValue(Double.NaN));
+
+		for (final Entry<SbdDataType, Double> entry : expectedValues.entrySet())
+		{
+			final SbdDataType dataType = entry.getKey();
+			final Double expected = entry.getValue();
+
+			assertThat(dataMap.get(dataType)).isEqualTo(expected);
+		}
+		assertThat(expectedValues.size()).isEqualTo(dataMap.size());
 	}
 
 }

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParserTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParserTest.java
@@ -3,7 +3,6 @@ package gov.usgs.warc.iridium.sbd.decoder.parser;
 import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.hexStringToByteArray;
 import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.setupMessageBytes;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -193,23 +192,6 @@ public class SbdParserTest
 		when(m_DecodeOrderRepository.findByStationId(m_StationIdTest))
 				.thenReturn(ParsingTestsHelper.getDecodeOrderSet());
 
-	}
-
-	/**
-	 * Test method for
-	 * {@link gov.usgs.warc.iridium.sbd.decoder.parser.SbdParser#getValuesFromMessage()}.
-	 *
-	 * @throws Exception
-	 */
-	@Test
-	public void testBadPayload() throws Exception
-	{
-		for (final List<Byte> bytes : ParsingTestsHelper
-				.getTestingDataBadPayload())
-		{
-			assertThatThrownBy(() -> new SbdParser(bytes))
-					.hasSameClassAs(new IllegalArgumentException());
-		}
 	}
 
 	/**
@@ -418,7 +400,6 @@ public class SbdParserTest
 	public void testProcessPayload() throws Exception
 	{
 		testProcessPayloadPsuedobinaryB();
-		testProcessPayloadPsuedobinaryBBad();
 		testProcessPayloadPsuedobinaryC();
 		testProcessPayloadPsuedobinaryD();
 		testProcessPayloadSutronStandardCsv();
@@ -447,28 +428,6 @@ public class SbdParserTest
 				.isEqualTo(PayloadType.PSEUDOBINARY_B_DATA_FORMAT);
 		assertThat(payload.getPayload().length)
 				.isEqualTo(payLoadBytes.getBytes().length - 4);
-	}
-
-	/**
-	 * Test method for
-	 * {@link gov.usgs.warc.iridium.sbd.decoder.parser.SbdParser#processPayload(java.nio.ByteBuffer)}.
-	 *
-	 * Original implementation for pseudobinary b format
-	 *
-	 * @throws Exception
-	 */
-	@Test
-	public void testProcessPayloadPsuedobinaryBBad() throws Exception
-	{
-		/**
-		 * Log using 'nc' to a text file and then use 'hexdump -c' to get
-		 * characters for this string.
-		 */
-		final String payLoadBytes = "0B1B?xd?zG@JM///O";
-		final ByteBuffer byteBuffer = ByteBuffer.wrap(payLoadBytes.getBytes());
-
-		assertThatThrownBy(() -> SbdParser.processPayload(byteBuffer))
-				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	/**

--- a/gov.usgs.warc.iridium.sbd.domain/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.domain/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.usgs.warc</groupId>
 	<artifactId>iridium.sbd.domain</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<name>USGS Iridium Short Burst Data (SBD) Decoder Library - Domain Interfaces</name>
 	<packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>gov.usgs.warc</groupId>
 	<artifactId>iridium.sbd.parent</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<name>All Modules</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
## 1.2.1 - 03/27/2019
 * Remove premature byte check for pseudobinary b format in SbdParser
 * Update PseudobinaryBPayloadDecoder to use a queue, be able to decode even if all expected types aren't present, and to be sensitive to "NaN" values