### PR TITLE
Add SpotBug, FindSecBugs, update to Spring Boot 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 jdk:
   - openjdk8
   - oraclejdk8
-  - openjdk11
   
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ jdk:
 dist: trusty
 
 script: 
- - mvn clean install   
+ - mvn install verify   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # USGS Iridium Short Burst Data (SBD) Decoder Library
 
+## 1.5.0 - 05/29/2020
+ * Integration of SpotBugs and address potential bugs reported
+ * Integration of FindSecBugs plugin into SpotBugs and address potential bugs reported
+ * Use ${revision} and ${changelist} in version string
+ * Update to Spring Boot 2.3.0
+ * Specify groupId for maven-compiler-plugin
+ * Specify version for maven-compiler-plugin and maven-surefire-plugin in .domain
+ * Update .project files for changes in <natures>
+ * Update travel.yml to 'install verify' instead of 'clean install'
+ * Add findbugs preference files
+
 ## 1.4.0 - 04/22/2020
  * Update to Spring Boot 2.2.6
  * Update to Guava 29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
  * Specify groupId for maven-compiler-plugin
  * Specify version for maven-compiler-plugin and maven-surefire-plugin in .domain
  * Update .project files for changes in <natures>
- * Update travel.yml to 'install verify' instead of 'clean install'
+ * Update travel.yml to 'install verify' instead of 'clean install', remove openjdk11 build 
  * Add findbugs preference files
 
 ## 1.4.0 - 04/22/2020

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "warc-iridium-sbd-decoder",
     "organization": "U.S. Geological Survey",
     "description": "USGS Iridium Short Burst Data (SBD) Decoder Library",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "status": "Beta",
 
     "permissions": {
@@ -43,7 +43,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2020-04-22"
+      "metadataLastUpdated": "2020-05-29"
     }
   }
 ]

--- a/gov.usgs.warc.iridium.sbd.decoder/.project
+++ b/gov.usgs.warc.iridium.sbd.decoder/.project
@@ -51,19 +51,23 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
+			<name>edu.umd.cs.findbugs.plugin.eclipse.findbugsBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.fusesource.ide.project.RiderProjectNature</nature>
-		<nature>org.springframework.ide.eclipse.core.springnature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
 		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
+		<nature>edu.umd.cs.findbugs.plugin.eclipse.findbugsNature</nature>
 	</natures>
 </projectDescription>

--- a/gov.usgs.warc.iridium.sbd.decoder/.settings/edu.umd.cs.findbugs.core.prefs
+++ b/gov.usgs.warc.iridium.sbd.decoder/.settings/edu.umd.cs.findbugs.core.prefs
@@ -1,0 +1,7 @@
+#SpotBugs User Preferences
+#Thu May 28 16:02:11 EDT 2020
+detector_threshold=2
+effort=max
+filter_settings=Medium|BAD_PRACTICE,CORRECTNESS,EXPERIMENTAL,I18N,MALICIOUS_CODE,MT_CORRECTNESS,PERFORMANCE,SECURITY,STYLE|false|15
+filter_settings_neg=NOISE|
+run_at_full_build=false

--- a/gov.usgs.warc.iridium.sbd.decoder/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.decoder/pom.xml
@@ -5,26 +5,31 @@
 
 	<groupId>gov.usgs.warc</groupId>
 	<artifactId>iridium.sbd.decoder</artifactId>
-	<version>1.4.0</version>
+	<version>${revision}${changelist}</version>
 	<name>USGS Iridium Short Burst Data (SBD) Decoder Library</name>
 	<packaging>jar</packaging>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.6.RELEASE</version>
+		<version>2.3.0.RELEASE</version>
 		<relativePath />
 	</parent>
 
 	<properties>
+		<revision>1.5.0</revision>
+		<changelist></changelist>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
+		<com.github.spotbugs_spotbugs-maven-plugin_version>4.0.0</com.github.spotbugs_spotbugs-maven-plugin_version>
+		<com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>1.10.1</com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>
 	</properties>
 
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<useIncrementalCompilation>false</useIncrementalCompilation>
@@ -42,6 +47,33 @@
 						<include>**/*Test.java</include>
 					</includes>
 				</configuration>
+			</plugin>
+			<!-- https://spotbugs.readthedocs.io/en/latest/maven.html -->
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>${com.github.spotbugs_spotbugs-maven-plugin_version}</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>Medium</threshold>
+					<failOnError>true</failOnError>
+					<plugins>
+						<plugin>
+							<groupId>com.h3xstream.findsecbugs</groupId>
+							<artifactId>findsecbugs-plugin</artifactId>
+							<version>${com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version}</version>
+						</plugin>
+					</plugins>
+				</configuration>
+				<executions>
+					<execution>
+						<id>spotbugs:check</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>
@@ -81,5 +113,31 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<!-- For @SuppressFBWarnings -->
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-maven-plugin</artifactId>
+			<version>${com.github.spotbugs_spotbugs-maven-plugin_version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-simple</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<!-- https://spotbugs.github.io/spotbugs-maven-plugin/usage.html -->
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>${com.github.spotbugs_spotbugs-maven-plugin_version}</version>
+				<configuration>
+					<xmlOutput>true</xmlOutput>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/directip/IridiumResponse.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/directip/IridiumResponse.java
@@ -1,12 +1,10 @@
 package gov.usgs.warc.iridium.sbd.decoder.directip;
 
 import com.google.common.collect.Table;
-
-import java.util.Collection;
-
 import gov.usgs.warc.iridium.sbd.decoder.parser.Message;
 import gov.usgs.warc.iridium.sbd.domain.SbdDataType;
 import gov.usgs.warc.iridium.sbd.domain.SbdStationId;
+import java.util.Collection;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -31,14 +29,14 @@ public class IridiumResponse
 	 *
 	 * @since Feb 12, 2018
 	 */
-	private Message												message;
+	private Message										message;
 
 	/**
 	 * The stations related to this response
 	 *
 	 * @since Feb 12, 2018
 	 */
-	private Collection<? extends SbdStationId>				stations;
+	private Collection<? extends SbdStationId>			stations;
 
 	/**
 	 * The map of data types to their corresponding values

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoder.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoder.java
@@ -2,6 +2,7 @@ package gov.usgs.warc.iridium.sbd.decoder.parser;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import gov.usgs.warc.iridium.sbd.decoder.parser.elements.Payload;
@@ -58,7 +59,8 @@ public class PseudobinaryBPayloadDecoder implements PayloadDecoder
 				"Invalid payload type for this decoder.");
 
 		final byte[] payload = p_Payload.getPayload();
-		log.info(String.format("Payload:%n%s", new String(payload)));
+		log.info(String.format("Payload:%n%s",
+				new String(payload, Charsets.UTF_8)));
 
 		final Queue<Byte> payloadQueue = Queues
 				.newArrayBlockingQueue(payload.length);

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoder.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoder.java
@@ -58,7 +58,7 @@ public class PseudobinaryBPayloadDecoder implements PayloadDecoder
 				"Invalid payload type for this decoder.");
 
 		final byte[] payload = p_Payload.getPayload();
-		log.info(String.format("Payload:\n%s", new String(payload)));
+		log.info(String.format("Payload:%n%s", new String(payload)));
 
 		final Queue<Byte> payloadQueue = Queues
 				.newArrayBlockingQueue(payload.length);

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
@@ -312,7 +312,7 @@ public class SbdParser
 		}
 
 		final byte id = 2;
-		final Payload payload = Payload.build(id, payloadType, payloadArray);
+		final Payload payload = Payload.builder(id, payloadType, payloadArray);
 		return payload;
 	}
 

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
@@ -312,8 +312,7 @@ public class SbdParser
 		}
 
 		final byte id = 2;
-		final Payload payload = Payload.builder(payloadType).id(id)
-				.payload(payloadArray).build();
+		final Payload payload = Payload.build(id, payloadType, payloadArray);
 		return payload;
 	}
 

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
@@ -3,6 +3,7 @@ package gov.usgs.warc.iridium.sbd.decoder.parser;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -81,8 +82,7 @@ public class SbdParser
 				String.format("Expected 15 bytes for imei but got %s",
 						p_ImeiByteArray.length));
 
-		return Long.parseLong(new String(p_ImeiByteArray));
-
+		return Long.parseLong(new String(p_ImeiByteArray, Charsets.UTF_8));
 	}
 
 	/**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParser.java
@@ -119,7 +119,7 @@ public class SbdParser
 		/**
 		 * Unused...direction string.
 		 */
-		String.format("%s%s", ns.name(), ew.name());
+		log.debug(String.format("%s%s", ns.name(), ew.name()));
 		final ByteBuffer byteBuffer = ByteBuffer.wrap(p_Bytes, 1, 6);
 		/**
 		 * Byte 2 lat degs

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoder.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoder.java
@@ -2,6 +2,7 @@ package gov.usgs.warc.iridium.sbd.decoder.parser;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -177,7 +178,8 @@ public class SutronStandardCsvPayloadDecoder implements PayloadDecoder
 				"Invalid payload type for this decoder.");
 
 		final Map<SbdDataType, Double> dataMap = Maps.newLinkedHashMap();
-		final String payload = new String(p_Payload.getPayload());
+		final String payload = new String(p_Payload.getPayload(),
+				Charsets.UTF_8);
 		log.info(String.format("Payload:%n%s", payload));
 		final Splitter splitter = Splitter.on(',');
 		try (Scanner scanner = new Scanner(payload))

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoder.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoder.java
@@ -178,7 +178,7 @@ public class SutronStandardCsvPayloadDecoder implements PayloadDecoder
 
 		final Map<SbdDataType, Double> dataMap = Maps.newLinkedHashMap();
 		final String payload = new String(p_Payload.getPayload());
-		log.info(String.format("Payload:\n%s", payload));
+		log.info(String.format("Payload:%n%s", payload));
 		final Splitter splitter = Splitter.on(',');
 		try (Scanner scanner = new Scanner(payload))
 		{
@@ -278,7 +278,7 @@ public class SutronStandardCsvPayloadDecoder implements PayloadDecoder
 		if (!findFirst.isPresent())
 		{
 			log.warn(String.format(
-					"No matching data type for (name: %s, units: %s) among:\n - %s",
+					"No matching data type for (name: %s, units: %s) among:%n - %s",
 					name, units,
 					p_DataTypes.stream()
 							.map(type -> String.format(

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Header.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Header.java
@@ -1,10 +1,9 @@
 package gov.usgs.warc.iridium.sbd.decoder.parser.elements;
 
+import gov.usgs.warc.iridium.sbd.decoder.parser.SessionStatus;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-
-import gov.usgs.warc.iridium.sbd.decoder.parser.SessionStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Payload.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Payload.java
@@ -35,7 +35,7 @@ public class Payload
 	 * @return a new builder to build instances of this class.
 	 * @since Jan 8, 2018
 	 */
-	public static Payload build(final byte p_Id,
+	public static Payload builder(final byte p_Id,
 			final PayloadType p_PayloadType, final byte[] p_Data)
 	{
 		return new PayloadBuilder()

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Payload.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Payload.java
@@ -6,6 +6,7 @@ import gov.usgs.warc.iridium.sbd.domain.SbdDataType;
 import gov.usgs.warc.iridium.sbd.domain.SbdDecodeOrder;
 import java.util.Map;
 import java.util.SortedSet;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,22 +19,29 @@ import lombok.ToString;
  * @since Jan 8, 2018
  *
  */
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @Getter
 @EqualsAndHashCode
 @ToString
 public class Payload
 {
 	/**
+	 * @param p_Id
+	 *            the id of the payload
 	 * @param p_PayloadType
 	 *            {@link PayloadType}
+	 * @param p_Data
+	 *            payload data
 	 * @return a new builder to build instances of this class.
 	 * @since Jan 8, 2018
 	 */
-	public static PayloadBuilder builder(final PayloadType p_PayloadType)
+	public static Payload build(final byte p_Id,
+			final PayloadType p_PayloadType, final byte[] p_Data)
 	{
-		return new PayloadBuilder().payloadType(
-				requireNonNull(p_PayloadType, "Payload type is required."));
+		return new PayloadBuilder()
+				.payloadType(requireNonNull(p_PayloadType,
+						"Payload type is required."))
+				.payload(p_Data.clone()).id(p_Id).build();
 	}
 
 	/**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Payload.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/Payload.java
@@ -81,4 +81,26 @@ public class Payload
 		return getPayloadType().getPayloadDecoder().decode(this, p_DataTypes,
 				p_DecodeOrder);
 	}
+
+	/**
+	 * Method added to address SpotBugs-reported issue: May expose internal
+	 * representation by returning reference to mutable object.
+	 *
+	 * Returning a reference to a mutable object value stored in one of the
+	 * object's fields exposes the internal representation of the object.  If
+	 * instances are accessed by untrusted code, and unchecked changes to the
+	 * mutable object would compromise security or other important properties,
+	 * you will need to do something different. Returning a new copy of the
+	 * object is better approach in many situations.
+	 *
+	 * Bug kind and pattern: EI - EI_EXPOSE_REP
+	 *
+	 * @return clone of {@link #payload}
+	 * @author mckelvym
+	 * @since May 29, 2020
+	 */
+	public byte[] getPayload()
+	{
+		return payload.clone();
+	}
 }

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/sixbitbinary/Decode.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/gov/usgs/warc/iridium/sbd/decoder/sixbitbinary/Decode.java
@@ -7,7 +7,6 @@ import static com.google.common.base.Preconditions.checkPositionIndex;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Range;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
@@ -1,6 +1,7 @@
 package test;
 
 import com.google.common.base.Charsets;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,7 +31,10 @@ public final class Echo
 	private static final Logger log = LoggerFactory.getLogger(Echo.class);
 
 	/**
-	 * Simple echo server
+	 * Simple echo server.
+	 *
+	 * Note: suppression of UNENCRYPTED_SERVER_SOCKET; this is a
+	 * proof-of-concept.
 	 *
 	 * @param p_Args
 	 *            one argument: port number to listen on.
@@ -40,6 +44,7 @@ public final class Echo
 	 * @author mckelvym
 	 * @since Jan 29, 2018
 	 */
+	@SuppressFBWarnings("UNENCRYPTED_SERVER_SOCKET")
 	public static void main(final String... p_Args)
 			throws NumberFormatException, UnknownHostException, IOException
 	{

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
@@ -49,10 +49,10 @@ public final class Echo
 			System.exit(1);
 		}
 
-		final String port = p_Args[0];
+		final String portS = p_Args[0];
+		final int port = Integer.parseInt(portS);
 		log.info(String.format("Listening on port %s", port));
-		try (final ServerSocket server = new ServerSocket(
-				Integer.parseInt(port));)
+		try (final ServerSocket server = new ServerSocket(port);)
 		{
 			while (true)
 			{
@@ -72,7 +72,8 @@ public final class Echo
 								inputStreamReader);)
 					{
 						final String readLine = bufferedReader.readLine();
-						log.info(String.format("Message: %s", readLine));
+						log.info(String.format("Message: %s",
+								readLine.replaceAll("\r\n", "\n")));
 						w.println("ACK");
 						w.println(readLine);
 					}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
@@ -80,9 +80,9 @@ public final class Echo
 				}
 			}
 		}
-		catch (final Exception e)
+		catch (final Throwable t)
 		{
-			log.error("Bad stuff happened.", e);
+			log.error("Bad stuff happened.", t);
 		}
 	}
 }

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Echo.java
@@ -1,13 +1,16 @@
 package test;
 
+import com.google.common.base.Charsets;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,14 +60,22 @@ public final class Echo
 				{
 					log.info(String.format("Client connected: %s",
 							client.getInetAddress()));
-					final PrintWriter w = new PrintWriter(
-							client.getOutputStream(), true);
-					final String readLine = new BufferedReader(
-							new InputStreamReader(client.getInputStream()))
-									.readLine();
-					log.info(String.format("Message: %s", readLine));
-					w.println("ACK");
-					w.println(readLine);
+					try (OutputStream outputStream = client.getOutputStream();
+						OutputStreamWriter outputStreamWriter = new OutputStreamWriter(
+								outputStream, Charsets.UTF_8);
+						final PrintWriter w = new PrintWriter(
+								outputStreamWriter, true);
+						InputStream inputStream = client.getInputStream();
+						InputStreamReader inputStreamReader = new InputStreamReader(
+								inputStream, Charsets.UTF_8);
+						BufferedReader bufferedReader = new BufferedReader(
+								inputStreamReader);)
+					{
+						final String readLine = bufferedReader.readLine();
+						log.info(String.format("Message: %s", readLine));
+						w.println("ACK");
+						w.println(readLine);
+					}
 				}
 			}
 		}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/SBDDecode.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/SBDDecode.java
@@ -3,7 +3,7 @@ package test;
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Files;
-
+import gov.usgs.warc.iridium.sbd.decoder.sixbitbinary.Decode;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -11,8 +11,6 @@ import java.nio.ByteOrder;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import gov.usgs.warc.iridium.sbd.decoder.sixbitbinary.Decode;
 
 /**
  * http://www.sutron.com/documents/xlite-9210b-user-manual-3.pdf
@@ -32,8 +30,7 @@ public class SBDDecode
 	public static void main(final String[] p_Args)
 			throws IOException, InterruptedException
 	{
-		final String path = p_Args[0];
-		final List<File> files = Lists.newArrayList(new File(path)
+		final List<File> files = Lists.newArrayList(new File(".")
 				.listFiles(file -> file.getName().endsWith(".sbd")));
 		Collections.sort(files);
 		for (final File file : files)

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Send.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Send.java
@@ -3,6 +3,7 @@ package test;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
@@ -62,10 +63,13 @@ public class Send
 	}
 
 	/**
+	 * Note: suppression of UNENCRYPTED_SOCKET; this is a proof-of-concept.
+	 *
 	 * @param p_Args
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
+	@SuppressFBWarnings("UNENCRYPTED_SOCKET")
 	public static void main(final String[] p_Args)
 			throws IOException, InterruptedException
 	{

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Send.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Send.java
@@ -1,5 +1,6 @@
 package test;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -117,7 +118,7 @@ public class Send
 		final Long expected = 300234010124740L;
 		final String str = Long.toString(expected);
 		final String finalStr = Strings.padStart(str, 15, '0');
-		final byte[] byteArray = finalStr.getBytes();
+		final byte[] byteArray = finalStr.getBytes(Charsets.UTF_8);
 		addBytestoListFromArray(byteList, hexStringToByteArray(revNum));
 		addBytestoListFromArray(byteList, hexStringToByteArray(msgLen));
 		addBytestoListFromArray(byteList, hexStringToByteArray(headerIEI));
@@ -147,11 +148,13 @@ public class Send
 					hexStringToByteArray(payLoadIE));
 			addBytestoListFromArray(payLoadByteList,
 					hexStringToByteArray(payLoadLen));
-			addBytestoListFromArray(payLoadByteList, payLoadBytes.getBytes());
+			addBytestoListFromArray(payLoadByteList,
+					payLoadBytes.getBytes(Charsets.UTF_8));
 
 			addBytestoListFromArray(byteList, hexStringToByteArray(payLoadIE));
 			addBytestoListFromArray(byteList, hexStringToByteArray(payLoadLen));
-			addBytestoListFromArray(byteList, payLoadBytes.getBytes());
+			addBytestoListFromArray(byteList,
+					payLoadBytes.getBytes(Charsets.UTF_8));
 		}
 
 		/**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Send.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/main/java/test/Send.java
@@ -2,9 +2,8 @@ package test;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.OutputStream;
 import java.net.Socket;
 import java.util.Arrays;
 import java.util.List;
@@ -72,13 +71,12 @@ public class Send
 		try (
 			final Socket echoSocket = new Socket(p_Args[0],
 					Integer.parseInt(p_Args[1]));
-			final PrintWriter out = new PrintWriter(
-					echoSocket.getOutputStream(), true);)
+			OutputStream outputStream = echoSocket.getOutputStream();)
 		{
 			final byte[] bytes = Objects
 					.requireNonNull(setupMessageBytes(p_Args[2]));
-			echoSocket.getOutputStream().write(bytes);
-			out.print(bytes);
+			outputStream.write(bytes);
+			outputStream.flush();
 		}
 		System.out.println("Done");
 	}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/Tests.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/Tests.java
@@ -2,13 +2,11 @@ package gov.usgs.warc.iridium.sbd.decoder;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Set;
 import java.util.SortedSet;
-
 import org.springframework.context.annotation.Bean;
 
 /**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/InformationElementIdentifiersTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/InformationElementIdentifiersTest.java
@@ -4,14 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-
+import gov.usgs.warc.iridium.sbd.decoder.Tests;
+import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import gov.usgs.warc.iridium.sbd.decoder.Tests;
-import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
-import gov.usgs.warc.iridium.sbd.decoder.parser.InformationElementIdentifiers;
 
 /**
  * Unit test for the {@link InformationElementIdentifiers}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/LocationDirectionTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/LocationDirectionTest.java
@@ -2,12 +2,10 @@ package gov.usgs.warc.iridium.sbd.decoder.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import gov.usgs.warc.iridium.sbd.decoder.Tests;
 import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
-import gov.usgs.warc.iridium.sbd.decoder.parser.LocationDirection;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * The location direction test

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/MessageTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/MessageTest.java
@@ -76,8 +76,8 @@ public class MessageTest
 		m_Header = Header.builder().cdrId(1).id('0').imei('1')
 				.length((short) 10).momsn((short) 0).mtmsn((short) 0)
 				.sessionTime(1081157732).status('1').build();
-		m_Payload = Payload.builder(PayloadType.PSEUDOBINARY_B_DATA_FORMAT)
-				.id((byte) 0x02).payload(new byte[] { (byte) 0x00 }).build();
+		m_Payload = Payload.build((byte) 0x02,
+				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, new byte[] { (byte) 0x00 });
 		m_LocationInformation = LocationInformation.builder().id((byte) 0x03)
 				.cepRadius(2000L).latitude(45.123).longitude(105.321).build();
 		m_Testable = Message.builder().header(m_Header).payLoad(m_Payload)

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/MessageTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/MessageTest.java
@@ -76,7 +76,7 @@ public class MessageTest
 		m_Header = Header.builder().cdrId(1).id('0').imei('1')
 				.length((short) 10).momsn((short) 0).mtmsn((short) 0)
 				.sessionTime(1081157732).status('1').build();
-		m_Payload = Payload.build((byte) 0x02,
+		m_Payload = Payload.builder((byte) 0x02,
 				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, new byte[] { (byte) 0x00 });
 		m_LocationInformation = LocationInformation.builder().id((byte) 0x03)
 				.cepRadius(2000L).latitude(45.123).longitude(105.321).build();

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/MessageTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/MessageTest.java
@@ -77,7 +77,8 @@ public class MessageTest
 				.length((short) 10).momsn((short) 0).mtmsn((short) 0)
 				.sessionTime(1081157732).status('1').build();
 		m_Payload = Payload.builder((byte) 0x02,
-				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, new byte[] { (byte) 0x00 });
+				PayloadType.PSEUDOBINARY_B_DATA_FORMAT,
+				new byte[] { (byte) 0x00 });
 		m_LocationInformation = LocationInformation.builder().id((byte) 0x03)
 				.cepRadius(2000L).latitude(45.123).longitude(105.321).build();
 		m_Testable = Message.builder().header(m_Header).payLoad(m_Payload)

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
@@ -88,7 +88,8 @@ public class PseudobinaryBPayloadDecoderTest
 		m_DecoderOrder = getDecodeOrderSet();
 		m_Testable = new PseudobinaryBPayloadDecoder();
 		m_Payload = Payload.builder((byte) 0x02,
-				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, "??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes());
+				PayloadType.PSEUDOBINARY_B_DATA_FORMAT,
+				"??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes());
 	}
 
 	/**
@@ -128,11 +129,13 @@ public class PseudobinaryBPayloadDecoderTest
 	@Test
 	public void testDecodeBadType()
 	{
-		assertThatThrownBy(() -> m_Testable.decode(
-				Payload.builder(m_Payload.getId(),
-						PayloadType.SUTRON_STANDARD_CSV, m_Payload.getPayload()),
-				m_DataTypes, m_DecoderOrder))
-						.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(
+				() -> m_Testable.decode(
+						Payload.builder(m_Payload.getId(),
+								PayloadType.SUTRON_STANDARD_CSV,
+								m_Payload.getPayload()),
+						m_DataTypes, m_DecoderOrder))
+								.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	/**
@@ -142,9 +145,9 @@ public class PseudobinaryBPayloadDecoderTest
 	@Test
 	public void testDecodeShortPayload()
 	{
-		final Payload payload = Payload.builder(
-				(byte) 0x02,
-				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, "?xd?zG@IC///J".getBytes());
+		final Payload payload = Payload.builder((byte) 0x02,
+				PayloadType.PSEUDOBINARY_B_DATA_FORMAT,
+				"?xd?zG@IC///J".getBytes());
 		final Map<SbdDataType, Double> dataMap = m_Testable.decode(payload,
 				m_DataTypes, m_DecoderOrder);
 

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
@@ -87,9 +87,8 @@ public class PseudobinaryBPayloadDecoderTest
 		m_DataTypes = Sets.newTreeSet(ParsingTestsHelper.getDataTypeSet());
 		m_DecoderOrder = getDecodeOrderSet();
 		m_Testable = new PseudobinaryBPayloadDecoder();
-		m_Payload = Payload.builder(PayloadType.PSEUDOBINARY_B_DATA_FORMAT)
-				.id((byte) 0x02)
-				.payload("??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes()).build();
+		m_Payload = Payload.build((byte) 0x02,
+				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, "??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes());
 	}
 
 	/**
@@ -129,13 +128,11 @@ public class PseudobinaryBPayloadDecoderTest
 	@Test
 	public void testDecodeBadType()
 	{
-		assertThatThrownBy(
-				() -> m_Testable.decode(
-						Payload.builder(PayloadType.SUTRON_STANDARD_CSV)
-								.id(m_Payload.getId())
-								.payload(m_Payload.getPayload()).build(),
-						m_DataTypes, m_DecoderOrder))
-								.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> m_Testable.decode(
+				Payload.build(m_Payload.getId(),
+						PayloadType.SUTRON_STANDARD_CSV, m_Payload.getPayload()),
+				m_DataTypes, m_DecoderOrder))
+						.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	/**
@@ -145,9 +142,9 @@ public class PseudobinaryBPayloadDecoderTest
 	@Test
 	public void testDecodeShortPayload()
 	{
-		final Payload payload = Payload
-				.builder(PayloadType.PSEUDOBINARY_B_DATA_FORMAT).id((byte) 0x02)
-				.payload("?xd?zG@IC///J".getBytes()).build();
+		final Payload payload = Payload.build(
+				(byte) 0x02,
+				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, "?xd?zG@IC///J".getBytes());
 		final Map<SbdDataType, Double> dataMap = m_Testable.decode(payload,
 				m_DataTypes, m_DecoderOrder);
 

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/PseudobinaryBPayloadDecoderTest.java
@@ -87,7 +87,7 @@ public class PseudobinaryBPayloadDecoderTest
 		m_DataTypes = Sets.newTreeSet(ParsingTestsHelper.getDataTypeSet());
 		m_DecoderOrder = getDecodeOrderSet();
 		m_Testable = new PseudobinaryBPayloadDecoder();
-		m_Payload = Payload.build((byte) 0x02,
+		m_Payload = Payload.builder((byte) 0x02,
 				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, "??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes());
 	}
 
@@ -129,7 +129,7 @@ public class PseudobinaryBPayloadDecoderTest
 	public void testDecodeBadType()
 	{
 		assertThatThrownBy(() -> m_Testable.decode(
-				Payload.build(m_Payload.getId(),
+				Payload.builder(m_Payload.getId(),
 						PayloadType.SUTRON_STANDARD_CSV, m_Payload.getPayload()),
 				m_DataTypes, m_DecoderOrder))
 						.isInstanceOf(IllegalArgumentException.class);
@@ -142,7 +142,7 @@ public class PseudobinaryBPayloadDecoderTest
 	@Test
 	public void testDecodeShortPayload()
 	{
-		final Payload payload = Payload.build(
+		final Payload payload = Payload.builder(
 				(byte) 0x02,
 				PayloadType.PSEUDOBINARY_B_DATA_FORMAT, "?xd?zG@IC///J".getBytes());
 		final Map<SbdDataType, Double> dataMap = m_Testable.decode(payload,

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParserTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParserTest.java
@@ -56,7 +56,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles("test")
 public class SbdParserTest
 {
-
 	/**
 	 * @author darceyj
 	 * @since Feb 12, 2018

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParserTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SbdParserTest.java
@@ -3,6 +3,7 @@ package gov.usgs.warc.iridium.sbd.decoder.parser;
 import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.hexStringToByteArray;
 import static gov.usgs.warc.iridium.sbd.decoder.ParsingTestsHelper.setupMessageBytes;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -32,9 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -119,15 +118,6 @@ public class SbdParserTest
 	 */
 	@MockBean
 	private SbdDecodeOrderProvider<SbdDecodeOrder>	m_DecodeOrderRepository;
-
-	/**
-	 * Rule for asserting that the proper exception is thrown
-	 *
-	 * @since Feb 2, 2018
-	 */
-	@Rule
-	public ExpectedException						m_ExpectedException	= ExpectedException
-			.none();
 
 	/**
 	 * The {@link SbdStationIdProvider}
@@ -374,7 +364,6 @@ public class SbdParserTest
 	public void testParse2() throws Exception
 	{
 		m_TestingByteList = setupMessageBytes("0D");
-		m_ExpectedException.expect(Exception.class);
 		final SbdParser parser = new SbdParser(m_TestingByteList);
 		final Optional<SbdStationId> opt = m_IridiumStationRepository
 				.findByImei(String
@@ -386,7 +375,8 @@ public class SbdParserTest
 		parser.setDecodeConfiguration(
 				m_DataTypeRepository.findByStationId(stationId),
 				m_DecodeOrderRepository.findByStationId(stationId));
-		parser.getValuesFromMessage();
+		assertThatThrownBy(() -> parser.getValuesFromMessage())
+				.isInstanceOf(Exception.class);
 	}
 
 	/**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SessionStatusTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SessionStatusTest.java
@@ -3,15 +3,11 @@ package gov.usgs.warc.iridium.sbd.decoder.parser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Maps;
-
+import gov.usgs.warc.iridium.sbd.decoder.Tests;
 import java.util.Map;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import gov.usgs.warc.iridium.sbd.decoder.Tests;
-import gov.usgs.warc.iridium.sbd.decoder.parser.SessionStatus;
 
 /**
  * Test the {@link SessionStatus}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoderTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoderTest.java
@@ -174,7 +174,7 @@ public class SutronStandardCsvPayloadDecoderTest
 				+ "03/21/2019,15:00:00,Baro MB,1020.4,F,G\r\n"
 				+ "03/21/2019,21:45:00,Prtctd,0.24,ft,G\r\n"
 				+ ":YB 13.95 :YN 073802332 :SN 1611330 ";
-		m_Payload = Payload.build((byte) 0x02,
+		m_Payload = Payload.builder((byte) 0x02,
 				PayloadType.SUTRON_STANDARD_CSV, payLoadBytes.getBytes());
 		m_Line = Lists.newArrayList("03/21/2019", "21:45:00", "Prtctd", "0.24",
 				"ft", "G");

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoderTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/SutronStandardCsvPayloadDecoderTest.java
@@ -174,8 +174,8 @@ public class SutronStandardCsvPayloadDecoderTest
 				+ "03/21/2019,15:00:00,Baro MB,1020.4,F,G\r\n"
 				+ "03/21/2019,21:45:00,Prtctd,0.24,ft,G\r\n"
 				+ ":YB 13.95 :YN 073802332 :SN 1611330 ";
-		m_Payload = Payload.builder(PayloadType.SUTRON_STANDARD_CSV)
-				.id((byte) 0x02).payload(payLoadBytes.getBytes()).build();
+		m_Payload = Payload.build((byte) 0x02,
+				PayloadType.SUTRON_STANDARD_CSV, payLoadBytes.getBytes());
 		m_Line = Lists.newArrayList("03/21/2019", "21:45:00", "Prtctd", "0.24",
 				"ft", "G");
 	}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/ConfirmationTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/ConfirmationTest.java
@@ -2,14 +2,12 @@ package gov.usgs.warc.iridium.sbd.decoder.parser.elements;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import gov.usgs.warc.iridium.sbd.decoder.Tests;
 import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
 import gov.usgs.warc.iridium.sbd.decoder.parser.InformationElementIdentifiers;
-import gov.usgs.warc.iridium.sbd.decoder.parser.elements.Confirmation;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test the Confirmation element

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/HeaderTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/HeaderTest.java
@@ -2,17 +2,14 @@ package gov.usgs.warc.iridium.sbd.decoder.parser.elements;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gov.usgs.warc.iridium.sbd.decoder.Tests;
+import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import gov.usgs.warc.iridium.sbd.decoder.Tests;
-import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
-import gov.usgs.warc.iridium.sbd.decoder.parser.elements.Header;
 
 /**
  * Test the header information element

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/LocationInformationTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/LocationInformationTest.java
@@ -2,13 +2,11 @@ package gov.usgs.warc.iridium.sbd.decoder.parser.elements;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gov.usgs.warc.iridium.sbd.decoder.Tests;
+import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import gov.usgs.warc.iridium.sbd.decoder.Tests;
-import gov.usgs.warc.iridium.sbd.decoder.Tests.SkipMethod;
-import gov.usgs.warc.iridium.sbd.decoder.parser.elements.LocationInformation;
 
 /**
  * Test the {@link LocationInformation} element

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/PayloadTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/PayloadTest.java
@@ -68,7 +68,7 @@ public class PayloadTest
 	{
 		m_PayloadType = PayloadType.PSEUDOBINARY_B_DATA_FORMAT;
 		m_PayloadBytes = "??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes();
-		m_Testable = Payload.build((byte) 0x02, m_PayloadType, m_PayloadBytes);
+		m_Testable = Payload.builder((byte) 0x02, m_PayloadType, m_PayloadBytes);
 	}
 
 	/**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/PayloadTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/PayloadTest.java
@@ -68,7 +68,8 @@ public class PayloadTest
 	{
 		m_PayloadType = PayloadType.PSEUDOBINARY_B_DATA_FORMAT;
 		m_PayloadBytes = "??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes();
-		m_Testable = Payload.builder((byte) 0x02, m_PayloadType, m_PayloadBytes);
+		m_Testable = Payload.builder((byte) 0x02, m_PayloadType,
+				m_PayloadBytes);
 	}
 
 	/**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/PayloadTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/parser/elements/PayloadTest.java
@@ -68,8 +68,7 @@ public class PayloadTest
 	{
 		m_PayloadType = PayloadType.PSEUDOBINARY_B_DATA_FORMAT;
 		m_PayloadBytes = "??T??\\@AB@@@@@i@@@B`e@@\\N".getBytes();
-		m_Testable = Payload.builder(m_PayloadType).id((byte) 0x02)
-				.payload(m_PayloadBytes).build();
+		m_Testable = Payload.build((byte) 0x02, m_PayloadType, m_PayloadBytes);
 	}
 
 	/**

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/sixbitbinary/BitStringTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/sixbitbinary/BitStringTest.java
@@ -3,16 +3,12 @@ package gov.usgs.warc.iridium.sbd.decoder.sixbitbinary;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Maps;
-
+import gov.usgs.warc.iridium.sbd.decoder.Tests;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import gov.usgs.warc.iridium.sbd.decoder.Tests;
-import gov.usgs.warc.iridium.sbd.decoder.sixbitbinary.BitString;
 
 /**
  * Test {@link BitString}

--- a/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/sixbitbinary/DecodeTest.java
+++ b/gov.usgs.warc.iridium.sbd.decoder/src/test/java/gov/usgs/warc/iridium/sbd/decoder/sixbitbinary/DecodeTest.java
@@ -3,18 +3,14 @@ package gov.usgs.warc.iridium.sbd.decoder.sixbitbinary;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Maps;
-
+import gov.usgs.warc.iridium.sbd.decoder.Tests;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import gov.usgs.warc.iridium.sbd.decoder.Tests;
-import gov.usgs.warc.iridium.sbd.decoder.sixbitbinary.Decode;
 
 /**
  * Test {@link Decode}

--- a/gov.usgs.warc.iridium.sbd.domain/.project
+++ b/gov.usgs.warc.iridium.sbd.domain/.project
@@ -45,14 +45,19 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>edu.umd.cs.findbugs.plugin.eclipse.findbugsBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.fusesource.ide.project.RiderProjectNature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
 		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
+		<nature>edu.umd.cs.findbugs.plugin.eclipse.findbugsNature</nature>
 	</natures>
 </projectDescription>

--- a/gov.usgs.warc.iridium.sbd.domain/.settings/edu.umd.cs.findbugs.core.prefs
+++ b/gov.usgs.warc.iridium.sbd.domain/.settings/edu.umd.cs.findbugs.core.prefs
@@ -1,0 +1,7 @@
+#SpotBugs User Preferences
+#Thu May 28 15:59:21 EDT 2020
+detector_threshold=2
+effort=max
+filter_settings=Medium|BAD_PRACTICE,CORRECTNESS,EXPERIMENTAL,I18N,MALICIOUS_CODE,MT_CORRECTNESS,PERFORMANCE,SECURITY,STYLE|false|15
+filter_settings_neg=NOISE|
+run_at_full_build=false

--- a/gov.usgs.warc.iridium.sbd.domain/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.domain/pom.xml
@@ -5,19 +5,25 @@
 
 	<groupId>gov.usgs.warc</groupId>
 	<artifactId>iridium.sbd.domain</artifactId>
-	<version>1.4.0</version>
+	<version>${revision}${changelist}</version>
 	<name>USGS Iridium Short Burst Data (SBD) Decoder Library - Domain Interfaces</name>
 	<packaging>jar</packaging>
 
 	<properties>
+		<revision>1.5.0</revision>
+		<changelist></changelist>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<com.github.spotbugs_spotbugs-maven-plugin_version>4.0.0</com.github.spotbugs_spotbugs-maven-plugin_version>
+		<com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>1.10.1</com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>
 	</properties>
 
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
 				<configuration>
 					<useIncrementalCompilation>false</useIncrementalCompilation>
 					<source>1.8</source>
@@ -27,6 +33,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
 				<configuration>
 					<!-- see: https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class -->
 					<argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
@@ -34,6 +41,33 @@
 						<include>**/*Test.java</include>
 					</includes>
 				</configuration>
+			</plugin>
+			<!-- https://spotbugs.readthedocs.io/en/latest/maven.html -->
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>${com.github.spotbugs_spotbugs-maven-plugin_version}</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>Medium</threshold>
+					<failOnError>true</failOnError>
+					<plugins>
+						<plugin>
+							<groupId>com.h3xstream.findsecbugs</groupId>
+							<artifactId>findsecbugs-plugin</artifactId>
+							<version>${com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version}</version>
+						</plugin>
+					</plugins>
+				</configuration>
+				<executions>
+					<execution>
+						<id>spotbugs:check</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>
@@ -50,4 +84,18 @@
 			<version>2.4.2</version>
 		</dependency>
 	</dependencies>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<!-- https://spotbugs.github.io/spotbugs-maven-plugin/usage.html -->
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>${com.github.spotbugs_spotbugs-maven-plugin_version}</version>
+				<configuration>
+					<xmlOutput>true</xmlOutput>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,22 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>gov.usgs.warc</groupId>
 	<artifactId>iridium.sbd.parent</artifactId>
-	<version>1.4.0</version>
-	<name>All Modules</name>
+	<version>${revision}${changelist}</version>
+	<name>USGS Iridium Short Burst Data (SBD) Decoder Library: All Modules</name>
 	<packaging>pom</packaging>
+
+	<properties>
+		<revision>1.5.0</revision>
+		<changelist></changelist>
+	</properties>
 
 	<modules>
 		<module>gov.usgs.warc.iridium.sbd.domain</module>
 		<module>gov.usgs.warc.iridium.sbd.decoder</module>
 	</modules>
+
 </project>


### PR DESCRIPTION
## 1.5.0 - 05/29/2020
 * Integration of SpotBugs and address potential bugs reported
 * Integration of FindSecBugs plugin into SpotBugs and address potential bugs reported
 * Use ${revision} and ${changelist} in version string
 * Update to Spring Boot 2.3.0
 * Specify groupId for maven-compiler-plugin
 * Specify version for maven-compiler-plugin and maven-surefire-plugin in .domain
 * Update .project files for changes in <natures>
 * Update travel.yml to 'install verify' instead of 'clean install'
 * Add findbugs preference files