### PR TITLE
WARC-1682 Explicitly specify property log4j2.version 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # USGS Iridium Short Burst Data (SBD) Decoder Library
 
+## 2.1.1 - 2021-12-15
+ * Explicitly specify property log4j2.version 2.16.0
+
 ## 2.1.0 - 2021-12-13
  * Explicitly specify property log4j2.version 2.15.0
  * Update Spring Boot to 2.6.1

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "warc-iridium-sbd-decoder",
     "organization": "U.S. Geological Survey",
     "description": "USGS Iridium Short Burst Data (SBD) Decoder Library",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "status": "Beta",
 
     "permissions": {
@@ -43,7 +43,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2021-12-13"
+      "metadataLastUpdated": "2021-12-5"
     }
   }
 ]

--- a/gov.usgs.warc.iridium.sbd.decoder/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.decoder/pom.xml
@@ -17,13 +17,13 @@
 	</parent>
 
 	<properties>
-		<revision>2.1.0</revision>
+		<revision>2.1.1</revision>
 		<changelist></changelist>
 		<com.github.spotbugs_spotbugs-maven-plugin_version>4.2.3</com.github.spotbugs_spotbugs-maven-plugin_version>
 		<com.google.guava.version>31.0.1-jre</com.google.guava.version>
 		<com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>1.11.0</com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>
 		<java.version>11</java.version>
-		<log4j2.version>2.15.0</log4j2.version>
+		<log4j2.version>2.16.0</log4j2.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/gov.usgs.warc.iridium.sbd.domain/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.domain/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<revision>2.1.0</revision>
+		<revision>2.1.1</revision>
 		<changelist></changelist>
 		<com.github.spotbugs_spotbugs-maven-plugin_version>4.2.3</com.github.spotbugs_spotbugs-maven-plugin_version>
 		<com.google.guava.version>31.0.1-jre</com.google.guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<revision>2.1.0</revision>
+		<revision>2.1.1</revision>
 		<changelist></changelist>
 	</properties>
 


### PR DESCRIPTION
## 2.1.1 - 2021-12-15
 * Explicitly specify property log4j2.version 2.16.0