### PR TITLE
Dependency updates: Update Spring Boot to 2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # USGS Iridium Short Burst Data (SBD) Decoder Library
 
+## 2.2.0 - 2022-01-04
+ * Explicitly specify property log4j2.version 2.17.1
+ * Update Spring Boot to 2.6.2
+
 ## 2.1.2 - 2021-12-20
  * Explicitly specify property log4j2.version 2.17.0
  * Explicitly specify property logback.version 1.2.9

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "warc-iridium-sbd-decoder",
     "organization": "U.S. Geological Survey",
     "description": "USGS Iridium Short Burst Data (SBD) Decoder Library",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "status": "Beta",
 
     "permissions": {
@@ -43,7 +43,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2021-12-20"
+      "metadataLastUpdated": "2022-01-04"
     }
   }
 ]

--- a/gov.usgs.warc.iridium.sbd.decoder/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.decoder/pom.xml
@@ -12,19 +12,18 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.1</version>
+		<version>2.6.2</version>
 		<relativePath />
 	</parent>
 
 	<properties>
-		<revision>2.1.2</revision>
+		<revision>2.2.0</revision>
 		<changelist></changelist>
 		<com.github.spotbugs_spotbugs-maven-plugin_version>4.2.3</com.github.spotbugs_spotbugs-maven-plugin_version>
 		<com.google.guava.version>31.0.1-jre</com.google.guava.version>
 		<com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>1.11.0</com.h3xstream.findsecbugs_com.h3xstream.findsecbugs_version>
 		<java.version>11</java.version>
-		<log4j2.version>2.17.0</log4j2.version>
-		<logback.version>1.2.9</logback.version>
+		<log4j2.version>2.17.1</log4j2.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/gov.usgs.warc.iridium.sbd.domain/pom.xml
+++ b/gov.usgs.warc.iridium.sbd.domain/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<revision>2.1.2</revision>
+		<revision>2.2.0</revision>
 		<changelist></changelist>
 		<com.github.spotbugs_spotbugs-maven-plugin_version>4.2.3</com.github.spotbugs_spotbugs-maven-plugin_version>
 		<com.google.guava.version>31.0.1-jre</com.google.guava.version>


### PR DESCRIPTION
## 2.2.0 - 2022-01-04
 * Explicitly specify property log4j2.version 2.17.1
 * Update Spring Boot to 2.6.2